### PR TITLE
Turn off non_camel_case_types lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         impl #ident {
             pub #signature -> Option<Self> {
+                #[allow(non_camel_case_types)]
                 struct discriminant;
                 #[allow(non_upper_case_globals)]
                 impl discriminant {


### PR DESCRIPTION
Closes #9.

It may be a rust-analyzer bug that caused a lint to be reported. I was not able to reproduce a warning in a rustc-based build.